### PR TITLE
Increase top margin on octopus to make hat fit

### DIFF
--- a/css/positioning/stylesheet.css
+++ b/css/positioning/stylesheet.css
@@ -4,14 +4,14 @@
     margin: 0 auto;
     left: 0;
     right: 0;
+    top: 30px;
 }
-
 #glasses{
-  position: absolute;
+    position: absolute;
 }
 
 #octopus{
   display: block;
   margin: 0 auto;
-  margin-top: 50px;
+  margin-top: 100px;
 }


### PR DESCRIPTION
Increase pixels on `margin-top` property on octopus.png to make hat fit (before, the hat was on the octopus' face)

Minor change: Add some pixels to `top` property on hat.png to make hat fit even better, and add space between top of page and hat.png
